### PR TITLE
BFGS instead of L-BFGS-B to avoid segfault with scipy > 1.8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python: [3.9]
+        python: [3.8]
         os: [ubuntu-latest]
 
     defaults:

--- a/debug.py
+++ b/debug.py
@@ -42,18 +42,15 @@ train_sd = pf.SpatialData(
 train_loss = pf.LossFunctional(train_sd, control, {"l2": [100, 100.], "smoothing": [1, 1.]})
 print("inv problem")
 invp = pf.InverseProblem(eqn, train_loss)
-options = {'ftol': 1e-8, 
-           'gtol': 1e-8, 
-           'maxcor': 15,
+options = {'gtol': 1e-8,
+           'xrtol': 1e-8,
            'maxiter': 100}
 print("optimize")
 m_hats, losses, results = invp.optimize(control, 
-                                        method='L-BFGS-B', 
+                                        method='BFGS', 
                                         options=options)
-
 print("solve")
 control.update(m_hats[-1])
 u_hat = eqn.solve()
-test_errors[fold] = test_loss.l2_error(u_hat)
 print("DONE")
 

--- a/product_fem/inverse_problems.py
+++ b/product_fem/inverse_problems.py
@@ -122,7 +122,7 @@ class InverseProblem:
         grad = self.compute_gradient(m, u)
         return loss, grad
     
-    def optimize(self, m0, method='L-BFGS-B', *args, **kwargs):
+    def optimize(self, m0, method='BFGS', *args, **kwargs):
         allvecs = [m0.array()]
         
         u0 = self.equation.solve(m0)

--- a/requirements/conda-environment.yml
+++ b/requirements/conda-environment.yml
@@ -4,11 +4,10 @@ channels:
   - anaconda
   - defaults
 dependencies:
-  - python==3.8.12
-  - fenics==2019.1.0
-  - matplotlib==3.5.1
-  - numpy==1.22.2
-  - scipy==1.8.0
-  - mshr==2019.1.0
-  - pip==23.0
-  - pandas==1.5.3
+  - python
+  - fenics
+  - matplotlib
+  - numpy
+  - scipy
+  - pandas
+  - mshr


### PR DESCRIPTION
- conda env now works without pinning any versions. 
- I'm not familiar enough to know if and how much estimates and runtimes have changed with switch to BFGS, but they look okay at a glance.
- added `'xrtol': 1e-8` to options dictionary in `debug.py`, though I have no idea about the appropriate scale. 
- Closes #21
